### PR TITLE
Do not insert the logger middleware when the logger doesn't have a formatter

### DIFF
--- a/lib/trashed/railtie.rb
+++ b/lib/trashed/railtie.rb
@@ -16,7 +16,7 @@ module Trashed
 
       def call(env)
         @app.call(env).tap do
-          env['trashed.logger.tags'] = Rails.logger.formatter.current_tags.dup
+          env['trashed.logger.tags'] = Array(Thread.current[:activesupport_tagged_logging_tags]).dup
         end
       end
     end


### PR DESCRIPTION
Rails 3.2 ActiveSupport::BufferedLogger doesn't have a formatter. Inserting this middleware prevents Trasher to work with that version of Rails out of the box. Since the gem claims to work in Rails 3, I though it would be a good idea to fix it here, rather than patching my application.

@jeremy would you mind to cut a new version of the gem when this is merged?

Thanks
