### PR TITLE
Avoid short lambdas to ensure gem works with "ancient" Ruby projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ allocated, etc.
 
 For example:
 ```ruby
-config.trashed.timing_dimensions = ->(env) do
+config.trashed.timing_dimensions = lambda do |env|
   # Rails 3 and 4 set this. Other Rack endpoints won't have it.
   if controller = env['action_controller.instance']
     name    = controller.controller_name
@@ -75,7 +75,7 @@ number of live String objects.
 For example:
 
 ```ruby
-config.trashed.gauge_dimensions = ->(env) {
+config.trashed.gauge_dimensions = lambda { |env|
   [ :All,
     :"Stage.#{Rails.env}",
     :"Hosts.#{`hostname -s`.chomp}" ]

--- a/lib/trashed/reporter.rb
+++ b/lib/trashed/reporter.rb
@@ -13,8 +13,8 @@ module Trashed
       @statsd = nil
       @timing_sample_rate = 0.1
       @gauge_sample_rate = 0.05
-      @timing_dimensions  = ->(env) { DEFAULT_DIMENSIONS }
-      @gauge_dimensions   = ->(env) { DEFAULT_DIMENSIONS }
+      @timing_dimensions  = lambda { |env| DEFAULT_DIMENSIONS }
+      @gauge_dimensions   = lambda { |env| DEFAULT_DIMENSIONS }
     end
 
     def report(env)

--- a/test/rack_test.rb
+++ b/test/rack_test.rb
@@ -21,7 +21,7 @@ class RackTest < Minitest::Test
   end
 
   def test_persistent_thread_state
-    app = ->(env) { env[Trashed::Rack::STATE][:persistent][:foo] = env[Trashed::Rack::STATE][:persistent][:foo].to_i + 1 }
+    app = lambda {|env| env[Trashed::Rack::STATE][:persistent][:foo] = env[Trashed::Rack::STATE][:persistent][:foo].to_i + 1 }
     rack = Trashed::Rack.new(app, @reporter)
 
     env = {}


### PR DESCRIPTION
Had some issues getting this to compile with my Rails 2.3.17/ruby 1.8.7 (2014-01-28 patchlevel 376) app due to the use of short lambdas. Should work as advertised for all versions of ruby.
