### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/trashed/railtie.rb
+++ b/lib/trashed/railtie.rb
@@ -28,8 +28,8 @@ module Trashed
       app.config.trashed.gauge_sample_rate ||= 0.05
       app.config.trashed.logger ||= Rails.logger
 
-      app.middleware.insert_after 'Rack::Runtime', Trashed::Rack, app.config.trashed
-      app.middleware.insert_after 'Rails::Rack::Logger', ExposeLoggerTagsToRackEnv
+      app.middleware.insert_after Rack::Runtime, Trashed::Rack, app.config.trashed
+      app.middleware.insert_after Rails::Rack::Logger, ExposeLoggerTagsToRackEnv
     end
   end
 end


### PR DESCRIPTION
This commit fixes the deprecation warnings coming from inserting
middleware. This just removes the quotes, per the deprecation warning:

```
DEPRECATION WARNING: Passing strings or symbols to the middleware
builder is deprecated, please change
them to actual class references.  For example:

  "Rack::Runtime" => Rack::Runtime
```