### PR TITLE
Split reporter in multiple reporters.

### DIFF
--- a/lib/trashed/railtie.rb
+++ b/lib/trashed/railtie.rb
@@ -4,7 +4,7 @@ require 'trashed/reporter'
 
 module Trashed
   class Railtie < ::Rails::Railtie
-    config.trashed = Trashed::Reporter.new
+    config.trashed = Trashed::Reporter::Aggregator.new
 
     # Middleware would like to emit tagged logs after Rails::Rack::Logger
     # pops its tags. Introduce this haxware to stash the tags in the Rack
@@ -22,11 +22,7 @@ module Trashed
     end
 
     initializer 'trashed' do |app|
-      require 'statsd'
-
-      app.config.trashed.timing_sample_rate ||= 0.1
-      app.config.trashed.gauge_sample_rate ||= 0.05
-      app.config.trashed.logger ||= Rails.logger
+      app.config.trashed.add_reporter Trashed::Reporter::Logger.new(Rails.logger)
 
       app.middleware.insert_after ::Rack::Runtime, Trashed::Rack, app.config.trashed
       app.middleware.insert_after ::Rails::Rack::Logger, ExposeLoggerTagsToRackEnv

--- a/lib/trashed/reporter.rb
+++ b/lib/trashed/reporter.rb
@@ -1,97 +1,10 @@
 require 'trashed/rack'
 
+require "trashed/reporter/aggregator"
+
 module Trashed
-  class Reporter
-    attr_accessor :logger, :statsd
-    attr_accessor :timing_sample_rate, :gauge_sample_rate
-    attr_accessor :timing_dimensions, :gauge_dimensions
-
-    DEFAULT_DIMENSIONS = [ :All ]
-
-    def initialize
-      @logger = nil
-      @statsd = nil
-      @timing_sample_rate = 0.1
-      @gauge_sample_rate = 0.05
-      @timing_dimensions  = ->(env) { DEFAULT_DIMENSIONS }
-      @gauge_dimensions   = ->(env) { DEFAULT_DIMENSIONS }
-    end
-
-    def report(env)
-      report_logger env if @logger
-      report_statsd env if @statsd
-    end
-
-    def report_logger(env)
-      timings = env[Trashed::Rack::TIMINGS]
-      parts = []
-
-      elapsed = '%.2fms' % timings[:'Time.wall']
-      if timings[:'Time.pct.cpu']
-        elapsed << ' (%.1f%% cpu, %.1f%% idle)' % timings.values_at(:'Time.pct.cpu', :'Time.pct.idle')
-      end
-      parts << elapsed
-
-      obj = timings[:'GC.allocated_objects'].to_i
-      parts << '%d objects' % obj unless obj.zero?
-
-      if gcs = timings[:'GC.count'].to_i
-        gc = '%d GCs' % gcs
-        unless gcs.zero?
-          if timings.include?(:'GC.major_count')
-            gc << ' (%d major, %d minor)' % timings.values_at(:'GC.major_count', :'GC.minor_count').map(&:to_i)
-          end
-          if timings.include?(:'GC.time')
-            gc << ' took %.2fms' % timings[:'GC.time']
-          end
-        end
-        parts << gc
-      end
-
-      oobgcs = timings[:'OOBGC.count'].to_i
-      if !oobgcs.zero?
-        oobgc = 'Avoided %d OOB GCs' % oobgcs
-        if timings[:'OOBGC.major_count']
-          oobgc << ' (%d major, %d minor, %d sweep)' % timings.values_at(:'OOBGC.major_count', :'OOBGC.minor_count', :'OOBGC.sweep_count').map(&:to_i)
-        end
-        if timings[:'OOBGC.time']
-          oobgc << ' saving %.2fms' % timings[:'OOBGC.time']
-        end
-        parts << oobgc
-      end
-
-      message = "Rack handled in #{parts * '. '}."
-
-      if @logger.respond_to?(:tagged) && env.include?('trashed.logger.tags')
-        @logger.tagged env['trashed.logger.tags'] do
-          @logger.info message
-        end
-      else
-        @logger.info message
-      end
-    end
-
-    def report_statsd(env)
-      method = @statsd.respond_to?(:easy) ? :easy : :batch
-      @statsd.send(method) do |statsd|
-        send_to_statsd statsd, :timing, @timing_sample_rate, env[Trashed::Rack::TIMINGS], :'Rack.Request', @timing_dimensions.call(env)
-        send_to_statsd statsd, :timing, @gauge_sample_rate,  env[Trashed::Rack::GAUGES],  :'Rack.Server',  @gauge_dimensions.call(env)
-      end
-    end
-
-    def send_to_statsd(statsd, method, sample_rate, measurements, namespace, dimensions)
-      measurements.each do |metric, value|
-        case value
-        when Array
-          value.each do |v|
-            send_to_statsd statsd, method, sample_rate, { metric => v }, namespace, dimensions
-          end
-        when Numeric
-          Array(dimensions || :All).each do |dimension|
-            statsd.send method, :"#{namespace}.#{dimension}.#{metric}", value, sample_rate
-          end
-        end
-      end
-    end
+  module Reporter
+    autoload :Logger, "trashed/reporter/logger"
+    autoload :Statsd, "trashed/reporter/statsd"
   end
 end

--- a/lib/trashed/reporter/aggregator.rb
+++ b/lib/trashed/reporter/aggregator.rb
@@ -1,0 +1,19 @@
+module Trashed
+  module Reporter
+    class Aggregator
+      def initialize
+        @reporters = []
+      end
+
+      def report(env)
+        @reporters.each do |reporter|
+          reporter.report(env)
+        end
+      end
+
+      def add_reporter(reporter)
+        @reporters << reporter if reporter && reporter.respond_to?(:report)
+      end
+    end
+  end
+end

--- a/lib/trashed/reporter/logger.rb
+++ b/lib/trashed/reporter/logger.rb
@@ -1,0 +1,62 @@
+module Trashed
+  module Reporter
+    class Logger
+      attr_accessor :logger
+
+      def initialize(logger = nil)
+        @logger = logger
+      end
+
+      def report(env)
+        return unless @logger
+
+        timings = env[Trashed::Rack::TIMINGS]
+        parts = []
+
+        elapsed = '%.2fms' % timings[:'Time.wall']
+        if timings[:'Time.pct.cpu']
+          elapsed << ' (%.1f%% cpu, %.1f%% idle)' % timings.values_at(:'Time.pct.cpu', :'Time.pct.idle')
+        end
+        parts << elapsed
+
+        obj = timings[:'GC.allocated_objects'].to_i
+        parts << '%d objects' % obj unless obj.zero?
+
+        if gcs = timings[:'GC.count'].to_i
+          gc = '%d GCs' % gcs
+          unless gcs.zero?
+            if timings.include?(:'GC.major_count')
+              gc << ' (%d major, %d minor)' % timings.values_at(:'GC.major_count', :'GC.minor_count').map(&:to_i)
+            end
+            if timings.include?(:'GC.time')
+              gc << ' took %.2fms' % timings[:'GC.time']
+            end
+          end
+          parts << gc
+        end
+
+        oobgcs = timings[:'OOBGC.count'].to_i
+        if !oobgcs.zero?
+          oobgc = 'Avoided %d OOB GCs' % oobgcs
+          if timings[:'OOBGC.major_count']
+            oobgc << ' (%d major, %d minor, %d sweep)' % timings.values_at(:'OOBGC.major_count', :'OOBGC.minor_count', :'OOBGC.sweep_count').map(&:to_i)
+          end
+          if timings[:'OOBGC.time']
+            oobgc << ' saving %.2fms' % timings[:'OOBGC.time']
+          end
+          parts << oobgc
+        end
+
+        message = "Rack handled in #{parts * '. '}."
+
+        if @logger.respond_to?(:tagged) && env.include?('trashed.logger.tags')
+          @logger.tagged env['trashed.logger.tags'] do
+            @logger.info message
+          end
+        else
+          @logger.info message
+        end
+      end
+    end
+  end
+end

--- a/lib/trashed/reporter/statsd.rb
+++ b/lib/trashed/reporter/statsd.rb
@@ -1,0 +1,46 @@
+module Trashed
+  module Reporter
+    class Statsd
+      require 'statsd'
+
+      attr_accessor :statsd
+      attr_accessor :timing_sample_rate, :gauge_sample_rate
+      attr_accessor :timing_dimensions, :gauge_dimensions
+
+      DEFAULT_DIMENSIONS = [ :All ]
+
+      def initialize(statsd = nil)
+        @statsd = statsd
+        @timing_sample_rate = 0.1
+        @gauge_sample_rate = 0.05
+        @timing_dimensions  = ->(env) { DEFAULT_DIMENSIONS }
+        @gauge_dimensions   = ->(env) { DEFAULT_DIMENSIONS }
+      end
+
+      def report(env)
+        return unless @statsd
+
+        method = @statsd.respond_to?(:easy) ? :easy : :batch
+        @statsd.send(method) do |statsd|
+          send_to_statsd statsd, :timing, @timing_sample_rate, env[Trashed::Rack::TIMINGS], :'Rack.Request', @timing_dimensions.call(env)
+          send_to_statsd statsd, :timing, @gauge_sample_rate,  env[Trashed::Rack::GAUGES],  :'Rack.Server',  @gauge_dimensions.call(env)
+        end
+      end
+
+      def send_to_statsd(statsd, method, sample_rate, measurements, namespace, dimensions)
+        measurements.each do |metric, value|
+          case value
+          when Array
+            value.each do |v|
+              send_to_statsd statsd, method, sample_rate, { metric => v }, namespace, dimensions
+            end
+          when Numeric
+            Array(dimensions || :All).each do |dimension|
+              statsd.send method, :"#{namespace}.#{dimension}.#{metric}", value, sample_rate
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change makes this library more agnostic to external metrics providers.

It allows users to plug their own reporters if they don't use statsd.

This change is not backwards compatible. I'm using it successfully, but feel free to not take it. I thought some people might be interested in it.

Signed-off-by: David Calavera <david.calavera@gmail.com>