### PR TITLE
Ruby 1.9.3 support

### DIFF
--- a/lib/trashed/instruments/ruby_gc.rb
+++ b/lib/trashed/instruments/ruby_gc.rb
@@ -9,6 +9,11 @@ module Trashed
         :count => :'GC.count'
       }
 
+      RUBY_2X_MEASUREMENTS = {
+        :major_gc_count => :'GC.major_count',
+        :minor_gc_count => :'GC.minor_gc_count'
+      }
+
       # Detect Ruby 1.9, 2.1 or 2.2 GC.stat naming
       begin
         GC.stat :total_allocated_objects
@@ -17,17 +22,17 @@ module Trashed
       rescue ArgumentError
         # Ruby 2.1
         MEASUREMENTS.update \
-          :total_allocated_object => :'GC.allocated_objects',
-          :total_freed_object => :'GC.freed_objects',
-          :major_gc_count => :'GC.major_count',
-          :minor_gc_count => :'GC.minor_gc_count'
+          RUBY_2X_MEASUREMENTS.merge(
+            :total_allocated_object => :'GC.allocated_objects',
+            :total_freed_object => :'GC.freed_objects'
+          )
       else
         # Ruby 2.2+
         MEASUREMENTS.update \
-          :total_allocated_objects => :'GC.allocated_objects',
-          :total_freed_objects => :'GC.freed_objects',
-          :major_gc_count => :'GC.major_count',
-          :minor_gc_count => :'GC.minor_gc_count'
+          RUBY_2X_MEASUREMENTS.merge(
+            :total_allocated_objects => :'GC.allocated_objects',
+            :total_freed_objects => :'GC.freed_objects'
+          )
       end
 
       def measure(state, timings, gauges)

--- a/lib/trashed/instruments/ruby_gc.rb
+++ b/lib/trashed/instruments/ruby_gc.rb
@@ -10,14 +10,18 @@ module Trashed
         :major_gc_count => :'GC.major_count',
         :minor_gc_count => :'GC.minor_gc_count' }
 
-      # Detect Ruby 2.1 vs 2.2 GC.stat naming
+      # Detect Ruby 1.9, 2.1 or 2.2 GC.stat naming
       begin
         GC.stat :total_allocated_objects
+      rescue TypeError
+        # Ruby 1.9, nothing to do
       rescue ArgumentError
+        # Ruby 2.1
         MEASUREMENTS.update \
           :total_allocated_object => :'GC.allocated_objects',
           :total_freed_object => :'GC.freed_objects'
       else
+        # Ruby 2.2+
         MEASUREMENTS.update \
           :total_allocated_objects => :'GC.allocated_objects',
           :total_freed_objects => :'GC.freed_objects'

--- a/lib/trashed/instruments/ruby_gc.rb
+++ b/lib/trashed/instruments/ruby_gc.rb
@@ -6,9 +6,8 @@ module Trashed
       end
 
       MEASUREMENTS = {
-        :count => :'GC.count',
-        :major_gc_count => :'GC.major_count',
-        :minor_gc_count => :'GC.minor_gc_count' }
+        :count => :'GC.count'
+      }
 
       # Detect Ruby 1.9, 2.1 or 2.2 GC.stat naming
       begin
@@ -19,12 +18,16 @@ module Trashed
         # Ruby 2.1
         MEASUREMENTS.update \
           :total_allocated_object => :'GC.allocated_objects',
-          :total_freed_object => :'GC.freed_objects'
+          :total_freed_object => :'GC.freed_objects',
+          :major_gc_count => :'GC.major_count',
+          :minor_gc_count => :'GC.minor_gc_count'
       else
         # Ruby 2.2+
         MEASUREMENTS.update \
           :total_allocated_objects => :'GC.allocated_objects',
-          :total_freed_objects => :'GC.freed_objects'
+          :total_freed_objects => :'GC.freed_objects',
+          :major_gc_count => :'GC.major_count',
+          :minor_gc_count => :'GC.minor_gc_count'
       end
 
       def measure(state, timings, gauges)

--- a/test/ruby_gc_profiler_test.rb
+++ b/test/ruby_gc_profiler_test.rb
@@ -27,18 +27,20 @@ if defined? GC::Profiler
       GC.start
       GC.start
 
+      elapsed = GC::Profiler.total_time
+
       if GC::Profiler.respond_to? :raw_data
-        elapsed = GC::Profiler.raw_data.inject(0) { |sum, d| sum + d[:GC_TIME] }
         intervals = GC::Profiler.raw_data.map { |d| d[:GC_INVOKE_TIME] }
       end
 
       timings, gauges = {}, []
       @instrument.send method, nil, timings, gauges
 
-      assert_equal 2, timings[:"#{captured}.count"]
+      assert_equal 1000 * elapsed, timings[:"#{captured}.time"]
 
       if GC::Profiler.respond_to? :raw_data
-        assert_equal 1000 * elapsed, timings[:"#{captured}.time"]
+        assert_equal 2, timings[:"#{captured}.count"]
+
         assert_equal intervals.map { |i| 1000 * i }, timings[:'GC.interval']
       end
     end


### PR DESCRIPTION
Fixes https://github.com/basecamp/trashed/issues/19.

The summary:
- `GC.count` metrics only was kept for Ruby 1.9.x
- The rest of metrics is collected for Ruby 2.x
- The tests have been fixed:
```
tsevan-trashed (ruby-193-support)$ rvm use 1.9.3 do rake
# Running:

...........

Finished in 0.015579s, 706.0787 runs/s, 3209.4486 assertions/s.

11 runs, 50 assertions, 0 failures, 0 errors, 0 skips

tsevan-trashed (ruby-193-support)$ rvm use 2.1.10 do rake
# Running:

............

Finished in 0.021146s, 567.4832 runs/s, 3121.1577 assertions/s.

12 runs, 66 assertions, 0 failures, 0 errors, 0 skips
tsevan-trashed (ruby-193-support)$ rvm use 2.4.2 do rake
# Running:

............

Finished in 0.021249s, 564.7325 runs/s, 3106.0285 assertions/s.

12 runs, 66 assertions, 0 failures, 0 errors, 0 skips
```